### PR TITLE
Fix reference to deprecated and removed "backgroundColor"

### DIFF
--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -53,7 +53,7 @@ class SkeletonAvatar extends StatelessWidget {
                       style.maxHeight ?? constraints.maxHeight)
                   : style.height,
               decoration: BoxDecoration(
-                color: Theme.of(context).backgroundColor,
+                color: Theme.of(context).scaffoldBackgroundColor,
                 shape: style.shape,
                 borderRadius:
                     style.shape != BoxShape.circle ? style.borderRadius : null,
@@ -97,7 +97,7 @@ class SkeletonLine extends StatelessWidget {
                       : style.width,
                   height: style.height,
                   decoration: BoxDecoration(
-                    color: Theme.of(context).backgroundColor,
+                    color: Theme.of(context).scaffoldBackgroundColor,
                     borderRadius: style.borderRadius,
                   ),
                 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: skeletons
 description: A Flutter package for building custom skeleton widgets to mimic the page's layout while loading.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/badjio/skeletons/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
See https://docs.flutter.dev/release/breaking-changes/3-19-deprecations
v0.3.3 of skeletons will no longer build with the flutter stable channel